### PR TITLE
style: escape brackets

### DIFF
--- a/_pages/imgpx.html
+++ b/_pages/imgpx.html
@@ -130,7 +130,7 @@ published: true
             <div class="column">
                 <h3>Quality</h3>
                 <p>Set the image quality. Use lower value to get smaller file size. Defaults to 50.</p>
-                <code>{{page.app_url}}/:image_url?quality=<10-100></code>
+                <code>{{page.app_url}}/:image_url?quality=&lt;10-100&gt;</code>
 
                 <h3>Example</h3>
                 <code><a href="{{page.app_url}}/{{page.imgdemo}}?quality=10" target="_blank">{{page.app_url}}/{{page.imgdemo}}?quality=10</a></code>


### PR DESCRIPTION
just realized I didn't escape `<>` in https://github.com/marsble/statically/pull/33. While browser can render it just fine, html-minifier (if used) would error out.