### PR TITLE
fix: use internal links

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,20 +1,20 @@
 <nav class="nav">
     <ul>
         <li{% if page.permalink == '/' %} class="active"{% endif %}>
-            <a href="{{site.url}}/"><i class="fa fa-home prime"></i> Home</a>
+            <a href="/"><i class="fa fa-home prime"></i> Home</a>
         </li>
         <li{% if page.permalink == '/imgpx' %} class="active"{% endif %}>
-            <a href="{{site.url}}/imgpx"><i class="fa fa-bolt optimus"></i> Imgpx</a>
+            <a href="/imgpx"><i class="fa fa-bolt optimus"></i> Imgpx</a>
         </li>
         </li>
         <li{% if page.permalink == '/sponsors' %} class="active"{% endif %}>
-            <a href="{{site.url}}/sponsors"><i class="fa fa-award bumble"></i> Sponsors</a>
+            <a href="/sponsors"><i class="fa fa-award bumble"></i> Sponsors</a>
         </li>
         <li{% if page.permalink == '/donate' %} class="active"{% endif %}>
-            <a href="{{site.url}}/donate"><i class="fa fa-heart pink"></i> Donate</a>
+            <a href="/donate"><i class="fa fa-heart pink"></i> Donate</a>
         </li>
         <li{% if page.permalink == '/network' %} class="active"{% endif %}>
-            <a href="{{site.url}}/network"><i class="fa fa-globe sentinel"></i> Network</a>
+            <a href="/network"><i class="fa fa-globe sentinel"></i> Network</a>
         </li>
         <li>
             <a class="gh" href="{{site.repo}}" target="_blank"><i class="fab fa-github"></i> GitHub</a>


### PR DESCRIPTION
Currently when previewing the page through Netlify deploy preview, the navigation links point to the production url. It should points to the deploy preview's url.